### PR TITLE
Make Framework/Core agnostic

### DIFF
--- a/APLSource/Main/Build/Zip.aplf
+++ b/APLSource/Main/Build/Zip.aplf
@@ -1,5 +1,5 @@
  zpath←temp Zip target;⎕USING;delete;name;path
 ⍝. This function zips the temp directory as target,'.xlsx'
-⍝. This is the only file that contains an external dependency of the .NET zip.dll
- ⎕USING←',System.IO.Compression.DLL' ',System.IO.Compression.FileSystem.DLL'
+⍝. This is the only file that contains an external dependency of the .NET zip library
+ ⎕USING←',System.IO.Compression' ',System.IO.Compression.FileSystem' ',System.IO.Compression.DLL' ',System.IO.Compression.FileSystem.DLL'
  System.IO.Compression.ZipFile.CreateFromDirectory temp (outputFile,'.xlsx')


### PR DESCRIPTION
This change allows APL2XL to be used under both the old .NET Framework (4.8) and the new .NET (previously known as ".NET Core") simply by having both library paths in `⎕USING`. Tested with both .NETs under Dyalog v19.0.